### PR TITLE
Make docker-compose work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM nginx:alpine
- 
-COPY nginx.conf /etc/nginx/nginx.conf
-
-RUN apk update && apk add bash
-
-CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,21 @@ version: '3'
  
 services:
     reverseproxy:
-        build: .
+        image: nginx:alpine
         ports:
             - 8080:8080
             - 8081:8081
         restart: always
- 
-    nginx:
+        volumes:
+            - ./nginx.conf:/etc/nginx/nginx.conf
         depends_on:
-            - reverseproxy
+            - nginx
+            - apache
+
+    nginx:
         image: nginx:alpine
         restart: always
  
     apache:
-        depends_on:
-            - reverseproxy
         image: httpd:alpine
         restart: always


### PR DESCRIPTION
Before this PR:

In one terminal:
```sh
$ docker-compose run reverseproxy
```

In another terminal:
```sh
$ curl http://127.0.0.1:8081
curl: (7) Failed to connect to 127.0.0.1 port 8081: Connection refused
```

This is because the entry command of the `reverseproxy` container is `bash`, so it won't run nginx at all.

Also, `docker-compose up` exits immediately (since it's starting with a non-interactive `bash` CMD).

---

With this PR, both `docker-compose up` and `docker-compose run reverseproxy` yield the expected results:
```sh
$ curl http://127.0.0.1:8081
<html><body><h1>It works!</h1></body></html>

$ curl http://127.0.0.1:8080
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
...
```

A note for `depends_on`: reverse proxy depends on the other two services (it cannot run by itself, otherwise it routes to nothing). Apache and Nginx can run perfectly well on their own, they don't depend on the reverse proxy.